### PR TITLE
Speed up the quoted printable encoding of big strings by avoiding the…

### DIFF
--- a/src/Mime.php
+++ b/src/Mime.php
@@ -118,38 +118,41 @@ class Mime
         $str = self::_encodeQuotedPrintable($str);
 
         // Split encoded text into separate lines
-        while ($str) {
-            $ptr = strlen($str);
-            if ($ptr > $lineLength) {
-                $ptr = $lineLength;
+        $initialPtr = 0;
+        $strLength = strlen($str);
+        while ($initialPtr < $strLength) {
+            $continueAt = $strLength - $initialPtr;
+
+            if ($continueAt > $lineLength) {
+                $continueAt = $lineLength;
             }
+
+            $chunk = substr($str, $initialPtr, $continueAt);
 
             // Ensure we are not splitting across an encoded character
-            $pos = strrpos(substr($str, 0, $ptr), '=');
-            if ($pos !== false && $pos >= $ptr - 2) {
-                $ptr = $pos;
+            $endingMarkerPos = strrpos($chunk, '=');
+            if ($endingMarkerPos !== false && $endingMarkerPos >= strlen($chunk) - 2) {
+                $chunk = substr($chunk, 0, $endingMarkerPos);
+                $continueAt = $endingMarkerPos;
             }
 
-            if (ord($str[0]) == 0x2E) { // 0x2E is a dot
-                $str  = '=2E' . substr($str, 1);
-                $ptr += 2;
+            if (ord($chunk[0]) == 0x2E) { // 0x2E is a dot
+                $chunk  = '=2E' . substr($chunk, 1);
             }
 
             // copied from swiftmailer https://git.io/vAXU1
-            switch (ord(substr($str, $ptr - 1))) {
+            switch (ord(substr($chunk, strlen($chunk) - 1))) {
                 case 0x09: // Horizontal Tab
-                    $str  = substr_replace($str, '=09', $ptr - 1, 1);
-                    $ptr += 2;
+                    $chunk = substr_replace($chunk, '=09', strlen($chunk) - 1, 1);
                     break;
                 case 0x20: // Space
-                    $str  = substr_replace($str, '=20', $ptr - 1, 1);
-                    $ptr += 2;
+                    $chunk = substr_replace($chunk, '=20', strlen($chunk) - 1, 1);
                     break;
             }
 
             // Add string and continue
-            $out .= substr($str, 0, $ptr) . '=' . $lineEnd;
-            $str = substr($str, $ptr);
+            $out .= $chunk . '=' . $lineEnd;
+            $initialPtr += $continueAt;
         }
 
         $out = rtrim($out, $lineEnd);

--- a/test/MimeTest.php
+++ b/test/MimeTest.php
@@ -298,4 +298,12 @@ n in das Wasser, Schw=C3=A4nzchen in die H=C3=B6h!'],
     {
         $this->assertEquals($expected, Mime\Mime::mimeDetectCharset($string));
     }
+
+    public function testEncodeQuotedPrintableShouldBeFastEnoughForLongInputStrings()
+    {
+        $str = str_repeat("this could be anything, ", 200000);
+        $time = microtime(true);
+        Mime\Mime::encodeQuotedPrintable($str);
+        $this->assertLessThan(5, microtime(true) - $time);
+    }
 }


### PR DESCRIPTION
… copy of the whole string on each iteration of the loop.

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description
When you try to "encodeQuotedPrintable()" of some real BIG string (our test case was 26 Megabytes long), the loop takes forever to end because it is copying the whole thing except the already processed lines on every iteration (the substr thing at the end). We could not even make it end (running for hours).
What I've done here is avoiding this copy and just use indexes where appropriate, only taking line chunks every time.
My English may not be so good so, hopefully you can understand what I'm talking about in this discussion: https://codereview.stackexchange.com/questions/7220/php-substr-slow, as it is the same exact situation.

The code itself maybe subject to improvements, could have been written better...
Hope it helps.

Regards.

