### PR TITLE
Adds two new mime type constants in email headers

### DIFF
--- a/docs/book/intro.md
+++ b/docs/book/intro.md
@@ -26,9 +26,11 @@ also be consumed by applications requiring general MIME support.
 `Laminas\Mime\Mime` defines a set of constants commonly used with MIME messages:
 
 - `Laminas\Mime\Mime::TYPE_ENRICHED`: 'text/enriched'
+- `Laminas\Mime\Mime::TYPE_APM`: 'text/x-amp-html'
 - `Laminas\Mime\Mime::TYPE_HTML`: 'text/html'
 - `Laminas\Mime\Mime::TYPE_OCTETSTREAM`: 'application/octet-stream'
 - `Laminas\Mime\Mime::TYPE_TEXT`: 'text/plain'
+- `Laminas\Mime\Mime::TYPE_WATCH`: 'text/watch-html'
 - `Laminas\Mime\Mime::TYPE_XML`: 'text/xml'
 - `Laminas\Mime\Mime::ENCODING_BASE64`: 'base64'
 - `Laminas\Mime\Mime::ENCODING_7BIT`: '7bit'

--- a/src/Mime.php
+++ b/src/Mime.php
@@ -15,9 +15,11 @@ class Mime
 {
     // @codingStandardsIgnoreStart
     const TYPE_OCTETSTREAM         = 'application/octet-stream';
+    const TYPE_APM                 = 'text/x-amp-html';
     const TYPE_TEXT                = 'text/plain';
     const TYPE_HTML                = 'text/html';
     const TYPE_ENRICHED            = 'text/enriched';
+    const TYPE_WATCH               = 'text/watch-html';
     const TYPE_XML                 = 'text/xml';
     const ENCODING_7BIT            = '7bit';
     const ENCODING_8BIT            = '8bit';


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
This is not really a bug fix but it extends the set of mime types in the class constants. I would optimize my system’s email sending strategy. You can manually specify the type as a string, but since these are existing types, it would be nice if I could refer to them as constants.

References:
https://amp.dev/documentation/guides-and-tutorials/learn/email-spec/amp-email-structure
https://www.emailmarketingtipps.de/2018/02/19/amp-for-email-controversies