### PR TITLE
Prevent adding duplicate parts to message #19

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -56,13 +56,11 @@ class Message
      */
     public function addPart(Part $part)
     {
-        foreach ($this->getParts() as $row) {
-            if ($part === $row) {
-                throw new Exception\InvalidArgumentException(sprintf(
-                    'Provided part %s already defined.',
-                    $part->getId()
-                ));
-            }
+        if (in_array($part, $this->getParts())) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Provided part %s already defined.',
+                $part->getId()
+            ));
         }
 
         $this->parts[] = $part;

--- a/src/Message.php
+++ b/src/Message.php
@@ -10,6 +10,7 @@ use function array_keys;
 use function base64_decode;
 use function count;
 use function current;
+use function in_array;
 use function quoted_printable_decode;
 use function sprintf;
 use function strlen;


### PR DESCRIPTION
Fixes #19 by using in_array, which performs a loose comparison by default.
