### PR TITLE
Do not pass null value to strtolower

### DIFF
--- a/src/Decode.php
+++ b/src/Decode.php
@@ -185,7 +185,7 @@ class Decode
      */
     public static function splitHeaderField($field, $wantedPart = null, $firstName = '0')
     {
-        $wantedPart = strtolower($wantedPart);
+        $wantedPart = strtolower($wantedPart ?? '');
         $firstName  = strtolower($firstName);
 
         // special case - a bit optimized


### PR DESCRIPTION
Found this while testing laminas-mail; `$wantedName` has a default `null` value, which means that when calling `strtolower()` on that value, we may raise a deprecation notice under 8.1 as `null` values are no longer allowed to that function.
