### PR TITLE
Prevent adding duplicate parts to message #19

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -10,6 +10,7 @@ use function array_keys;
 use function base64_decode;
 use function count;
 use function current;
+use function in_array;
 use function quoted_printable_decode;
 use function sprintf;
 use function strlen;
@@ -56,13 +57,11 @@ class Message
      */
     public function addPart(Part $part)
     {
-        foreach ($this->getParts() as $row) {
-            if ($part === $row) {
-                throw new Exception\InvalidArgumentException(sprintf(
-                    'Provided part %s already defined.',
-                    $part->getId()
-                ));
-            }
+        if (in_array($part, $this->getParts())) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Provided part %s already defined.',
+                $part->getId()
+            ));
         }
 
         $this->parts[] = $part;

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -189,7 +189,7 @@ EOD;
         $this->assertEquals('', $mimeMessage->generateMessage());
     }
 
-    public function testDuplicatePartAddedWillThrowException()
+    public function testPartAddedMoreThanOnceWillThrowException()
     {
         $this->expectException(Mime\Exception\InvalidArgumentException::class);
 
@@ -197,6 +197,17 @@ EOD;
         $part    = new Mime\Part('This is a test');
         $message->addPart($part);
         $message->addPart($part);
+    }
+
+    public function testDuplicatePartAddedWillThrowException()
+    {
+        $this->expectException(Mime\Exception\InvalidArgumentException::class);
+
+        $message = new Mime\Message();
+        $part1    = new Mime\Part('This is a test');
+        $part2    = new Mime\Part('This is a test');
+        $message->addPart($part1);
+        $message->addPart($part2);
     }
 
     public function testFromStringWithCrlfAndRfc2822FoldedHeaders()

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -204,8 +204,8 @@ EOD;
         $this->expectException(Mime\Exception\InvalidArgumentException::class);
 
         $message = new Mime\Message();
-        $part1    = new Mime\Part('This is a test');
-        $part2    = new Mime\Part('This is a test');
+        $part1   = new Mime\Part('This is a test');
+        $part2   = new Mime\Part('This is a test');
         $message->addPart($part1);
         $message->addPart($part2);
     }


### PR DESCRIPTION
Fixes #19 by using in_array, which performs a loose comparison by default. Add unit test to cover duplicate part addition, alongside existing test that covers adding the _exact same_ part multiple times.
