### PR TITLE
Attachments with longs names are not being processed

### DIFF
--- a/src/Decode.php
+++ b/src/Decode.php
@@ -199,17 +199,26 @@ class Decode
             throw new Exception\RuntimeException('not a valid header field');
         }
 
+        $fullField = [];
         if ($wantedPart) {
             foreach ($matches[1] as $key => $name) {
-                if (strcasecmp($name, $wantedPart)) {
+
+                if (!preg_match('/' . preg_quote($wantedPart) . "(\*[0-9])*" . '/', $name)) { //support multiname
                     continue;
                 }
-                if ($matches[2][$key][0] !== '"') {
-                    return $matches[2][$key];
+
+                $val = $matches[2][$key][0] != '"' ? $matches[2][$key] : substr($matches[2][$key], 1, -1);
+
+                // if name and wantedPart doees not match fully(they have matched above in the regex),
+                // it means that we have multiple values
+                if (strcasecmp($name, $wantedPart) && gettype($val) === 'string') {
+                    $fullField[$wantedPart] .= $val;
+                } else {// name and wantedPart match
+                    return $val;
                 }
-                return substr($matches[2][$key], 1, -1);
+
             }
-            return;
+            return $fullField[$wantedPart] ?: null;
         }
 
         $split = [];


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Bug Report

<!-- Fill in the relevant information below to help triage your issue. -->

|    Q        |   A
|------------ | ------
| Version(s)  | 2.10.x

#### Summary

Attachments with filenames, longer than 76 char symbols, are not being processed.

#### Current behavior

Currently, Laminas\Mail successfully identifies long names and successfully splits them into multiple variables in \Laminas\Mail\Header\ContentDisposition::getFieldValue().
However, the multiple variables do not get recognized in Laminas\Mime\Decode::splitHeaderField() due to this check 
`strcasecmp($name, $wantedPart)`
i.e. it compares "filename*0" with "filename"

#### How to reproduce

Try to process an email with an attachment with long name, for example
"This_______________________________________________________is____________________long__________________________________name.txt"


#### Expected behavior

It should not compare with strcasecmp, but rather with a regex. Then if it is a multiple value, it should concatenate the values
