### PR TITLE
Add the ability to store multipart/alternative messages

### DIFF
--- a/docs/book/message.md
+++ b/docs/book/message.md
@@ -3,7 +3,7 @@
 `Laminas\Mime\Message` represents a MIME compliant message that can contain one or
 more separate Parts (represented as [Laminas\Mime\Part](part.md) instances).
 Encoding and boundary handling are handled transparently by the class.
-`Message` instances can also be generated from MIME strings.
+`Message` instances can also be generated from MIME-compliant strings.
 
 ## Instantiation
 
@@ -16,7 +16,7 @@ calling `->addPart($part)`
 
 An array with all [Part](part.md) instances in the `Message` is returned from
 the method `getParts()`. The `Part` instances can then be modified on
-retrieveal, as they are stored in the array as references. If parts are added
+retrieval, as they are stored in the array as references. If parts are added
 to the array or the sequence is changed, the array needs to be passed back to
 the `Message` instance by calling `setParts($partsArray)`.
 
@@ -46,7 +46,7 @@ strings and returning a `Laminas\Mime\Message` instance:
 $message = Laminas\Mime\Message::createFromMessage($string, $boundary);
 ```
 
-As of version 2.6.1, You may also parse a single-part message by omitting the
+As of version 2.6.1, you may also parse a single-part message by omitting the
 `$boundary` argument:
 
 ```php

--- a/src/Message.php
+++ b/src/Message.php
@@ -33,7 +33,7 @@ class Message
      *
      * @return Part[]
      */
-    public function getParts()
+    public function getParts(): array
     {
         return $this->parts;
     }

--- a/src/Message.php
+++ b/src/Message.php
@@ -22,8 +22,6 @@ use function trim;
 
 class Message
 {
-    const CONTENT_TYPE_MULTIPART_ALTERNATIVE = "multipart/alternative";
-
     /** @var Part[] */
     protected $parts = [];
 
@@ -323,7 +321,7 @@ class Message
              */
             if (
                 $headers->has('content-type')
-                && $headers->get('content-type')->getType() === self::CONTENT_TYPE_MULTIPART_ALTERNATIVE
+                && $headers->get('content-type')->getType() === \Laminas\Mime\Mime::MULTIPART_ALTERNATIVE
             ) {
                 /** @var ContentType $contentTypeHeader */
                 $contentTypeHeader = $headers->get('content-type');

--- a/src/Message.php
+++ b/src/Message.php
@@ -12,7 +12,6 @@ use function count;
 use function current;
 use function quoted_printable_decode;
 use function sprintf;
-use function str_starts_with;
 use function strlen;
 use function strpos;
 use function strtolower;
@@ -336,10 +335,7 @@ class Message
                 if ($headers->has('content-disposition')) {
                     /** @var ContentDisposition $header */
                     $header = $headers->get('content-disposition');
-                    if (
-                        str_starts_with($header->getFieldValue(), 'attachment')
-                        && $header->getParameter('filename') !== null
-                    ) {
+                    if ($header->getParameter('filename') !== null) {
                         $newPart->setFileName($header->getParameter('filename'));
                     }
                 }

--- a/src/Message.php
+++ b/src/Message.php
@@ -327,7 +327,7 @@ class Message
             ) {
                 /** @var ContentType $contentTypeHeader */
                 $contentTypeHeader = $headers->get('content-type');
-                
+
                 $message = self::createFromMessage($body, $contentTypeHeader->getParameter('boundary'), $EOL);
                 $newPart = new Part();
                 foreach ($message->getParts() as $alternativePart) {

--- a/src/Message.php
+++ b/src/Message.php
@@ -141,13 +141,13 @@ class Message
 
             $boundaryLine = $mime->boundaryLine($EOL);
             $body         = 'This is a message in Mime Format.  If you see this, '
-                  . "your mail reader does not support this format." . $EOL;
+                . "your mail reader does not support this format." . $EOL;
 
             foreach (array_keys($this->parts) as $p) {
                 $body .= $boundaryLine
-                       . $this->getPartHeaders($p, $EOL)
-                       . $EOL
-                       . $this->getPartContent($p, $EOL);
+                    . $this->getPartHeaders($p, $EOL)
+                    . $EOL
+                    . $this->getPartContent($p, $EOL);
             }
 
             $body .= $mime->mimeEnd($EOL);
@@ -321,7 +321,7 @@ class Message
              */
             if (
                 $headers->has('content-type')
-                && $headers->get('content-type')->getType() === \Laminas\Mime\Mime::MULTIPART_ALTERNATIVE
+                && $headers->get('content-type')->getType() === Mime::MULTIPART_ALTERNATIVE
             ) {
                 /** @var ContentType $contentTypeHeader */
                 $contentTypeHeader = $headers->get('content-type');
@@ -333,9 +333,9 @@ class Message
                 }
             } else {
                 $newPart = new Part($body);
-                foreach ($properties as $key => $value) {
-                    $newPart->$key = $value;
-                }
+            }
+            foreach ($properties as $key => $value) {
+                $newPart->$key = $value;
             }
 
             $res->addPart($newPart);

--- a/src/Message.php
+++ b/src/Message.php
@@ -2,18 +2,17 @@
 
 namespace Laminas\Mime;
 
+use Laminas\Mail\Header\ContentDisposition;
 use Laminas\Mail\Header\ContentType;
 use Laminas\Mail\Header\HeaderInterface;
 use Laminas\Mail\Headers;
-use Laminas\Mime\Mime;
-use Laminas\Mime\Part;
-
 use function array_keys;
 use function base64_decode;
 use function count;
 use function current;
 use function quoted_printable_decode;
 use function sprintf;
+use function str_starts_with;
 use function strlen;
 use function strpos;
 use function strtolower;
@@ -333,6 +332,17 @@ class Message
                 }
             } else {
                 $newPart = new Part($body);
+
+                if ($headers->has('content-disposition')) {
+                    /** @var ContentDisposition $header */
+                    $header = $headers->get('content-disposition');
+                    if (
+                        str_starts_with($header->getFieldValue(), 'attachment')
+                        && $header->getParameter('filename') !== null
+                    ) {
+                        $newPart->setFileName($header->getParameter('filename'));
+                    }
+                }
             }
             foreach ($properties as $key => $value) {
                 $newPart->$key = $value;

--- a/src/Part.php
+++ b/src/Part.php
@@ -72,7 +72,7 @@ class Part
      * at this point, is to only store Part objects built from parsing
      * Messages with a content-type of "multipart/alternative".
      *
-     * @var array<array-key, Part>
+     * @var Part[]
      */
     protected array $parts = [];
 

--- a/src/Part.php
+++ b/src/Part.php
@@ -68,7 +68,7 @@ class Part
      * Stores a list of sub parts of this part
      *
      * It supports RFC 1341 7.2.3: "The Multipart/alternative subtype".
-     * While it can a list of parts without limitation, the intention,
+     * While it can store a list of parts without limitation, the intention,
      * at this point, is to only store Part objects built from parsing
      * Messages with a content-type of "multipart/alternative".
      *

--- a/src/Part.php
+++ b/src/Part.php
@@ -65,6 +65,33 @@ class Part
     protected $filters = [];
 
     /**
+     * Stores a list of sub parts of this part
+     *
+     * It supports RFC 1341 7.2.3: "The Multipart/alternative subtype".
+     * While it can a list of parts without limitation, the intention,
+     * at this point, is to only store Part objects built from parsing
+     * Messages with a content-type of "multipart/alternative".
+     *
+     * @var array<array-key, Part>
+     */
+    protected array $parts = [];
+
+    /**
+     * Retrieve the sub-Parts of this Part
+     *
+     * @return Part[]
+     */
+    public function getParts(): array
+    {
+        return $this->parts;
+    }
+
+    public function addPart(Part $part): void
+    {
+        $this->parts[] = $part;
+    }
+
+    /**
      * create a new Mime Part.
      * The (unencoded) content of the Part as passed
      * as a string or stream

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -401,5 +401,31 @@ EOF;
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document;\r\n name=\"DockMcWordface.docx\"",
             $headers->get('Content-Type')->getFieldValue()
         );
+
+        $attachments = array_filter($parts, function ($part, $index) {
+            return str_starts_with(
+                (string) $part->getDisposition(),
+                "attachment"
+            );
+        }, ARRAY_FILTER_USE_BOTH);
+        $this->assertCount(1, $attachments);
+
+        $nonAttachments = array_filter($parts, function ($part, $index) {
+            return ! str_starts_with(
+                (string) $part->getDisposition(),
+                "attachment"
+            );
+        }, ARRAY_FILTER_USE_BOTH);
+        $this->assertCount(1, $nonAttachments);
+        $this->assertCount(2, $nonAttachments[0]->getParts());
+
+        /** @var Part[] $noteParts */
+        $noteParts = array_filter($nonAttachments[0]->getParts(), function ($part, $index) {
+            return str_starts_with(
+                (string) $part->getType(),
+                "text/plain"
+            );
+        }, ARRAY_FILTER_USE_BOTH);
+        $this->assertSame("This is a test email with 1 attachment.", trim($noteParts[0]->getContent()));
     }
 }

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -402,6 +402,8 @@ EOL;
             );
         }, ARRAY_FILTER_USE_BOTH);
         $this->assertCount(1, $attachments);
+        $docAttachment = $attachments[1];
+        $this->assertSame("DockMcWordface.docx", $docAttachment->getFileName());
 
         $nonAttachments = array_filter($parts, function ($part, $index) {
             return ! str_starts_with(

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -245,11 +245,7 @@ This is a test email with 1 attachment.
 Content-Type: text/html; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 
-<div dir=3D"ltr">This is a test email with 1 attachment.<br clear=3D"all"><=
-div><br></div>-- <br><div class=3D"gmail_signature" data-smartmail=3D"gmail=
-_signature"><div dir=3D"ltr"><img src=3D"https://sendgrid.com/brand/sg-logo=
--email.png" width=3D"96" height=3D"17"><br><div><br></div></div></div>
-</div>
+<div>This is a test email with 1 attachment.</div>
 
 --001a11447dc881e40b0537fe6d58--
 
@@ -380,10 +376,7 @@ EOL;
         $this->assertTrue($headers->has('Content-Transfer-Encoding'));
         $this->assertSame("quoted-printable", $headers->get('Content-Transfer-Encoding')->getFieldValue());
 
-        $htmlBody = <<<EOF
-<div dir="ltr">This is a test email with 1 attachment.<br clear="all"><div><br></div>-- <br><div class="gmail_signature" data-smartmail="gmail_signature"><div dir="ltr"><img src="https://sendgrid.com/brand/sg-logo-email.png" width="96" height="17"><br><div><br></div></div></div>
-</div>
-EOF;
+        $htmlBody = "<div>This is a test email with 1 attachment.</div>";
         $this->assertSame($htmlBody, trim($htmlPart->getRawContent()));
 
         $this->assertInstanceOf(Part::class, $parts[1]);

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -6,15 +6,20 @@ namespace LaminasTest\Mime;
 
 use Laminas\Mail\Headers;
 use Laminas\Mime;
-use Laminas\Mime\AlternativePart;
 use Laminas\Mime\Message;
 use Laminas\Mime\Part;
 use PHPUnit\Framework\TestCase;
 
+use function array_filter;
 use function count;
 use function current;
+use function str_replace;
+use function str_starts_with;
 use function strlen;
 use function strpos;
+use function trim;
+
+use const ARRAY_FILTER_USE_BOTH;
 
 /**
  * @group      Laminas_Mime
@@ -353,10 +358,10 @@ AFtDb250ZW50X1R5cGVzXS54bWxQSwUGAAAAAAgACAD/AQAAmw4AAAAA
 
 --001a11447dc881e40f0537fe6d5a--
 EOL;
-        $boundary = '001a11447dc881e40f0537fe6d5a';
+        $boundary   = '001a11447dc881e40f0537fe6d5a';
 
         $message = Message::createFromMessage($rawMessage, $boundary);
-        $parts = $message->getParts();
+        $parts   = $message->getParts();
 
         $this->assertCount(2, $parts);
 

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 use function array_filter;
 use function count;
 use function current;
+use function preg_match;
 use function str_replace;
 use function str_starts_with;
 use function strlen;
@@ -395,16 +396,6 @@ EOL;
             $headers->get('Content-Type')->getFieldValue()
         );
 
-        $attachments = array_filter($parts, function ($part, $index) {
-            return str_starts_with(
-                (string) $part->getDisposition(),
-                "attachment"
-            );
-        }, ARRAY_FILTER_USE_BOTH);
-        $this->assertCount(1, $attachments);
-        $docAttachment = $attachments[1];
-        $this->assertSame("DockMcWordface.docx", $docAttachment->getFileName());
-
         $nonAttachments = array_filter($parts, function ($part, $index) {
             return ! str_starts_with(
                 (string) $part->getDisposition(),
@@ -422,5 +413,284 @@ EOL;
             );
         }, ARRAY_FILTER_USE_BOTH);
         $this->assertSame("This is a test email with 1 attachment.", trim($noteParts[0]->getContent()));
+    }
+
+    /**
+     * @dataProvider emailDataProvider
+     */
+    public function testAttachmentWillHaveFilenameIfTheFilenameIsSetInTheContentDispositionHeader(
+        string $email,
+        ?string $filename
+    ) {
+        $message     = Message::createFromMessage($email, '001a11447dc881e40f0537fe6d5a');
+        $attachments = array_filter($message->getParts(), function ($part, $index) {
+            return preg_match(
+                '/^(attachment|inline)/',
+                (string) $part->getDisposition()
+            ) === 1;
+        }, ARRAY_FILTER_USE_BOTH);
+        $this->assertCount(1, $attachments);
+        $docAttachment = $attachments[1];
+        $this->assertSame($filename, $docAttachment->getFileName());
+    }
+
+    public function emailDataProvider(): array
+    {
+        $messageWithAttachmentFilename = <<<EOL
+--001a11447dc881e40f0537fe6d5a
+Content-Type: multipart/alternative; boundary=001a11447dc881e40b0537fe6d58
+
+--001a11447dc881e40b0537fe6d58
+Content-Type: text/plain; charset=UTF-8
+
+This is a test email with 1 attachment.
+
+--001a11447dc881e40b0537fe6d58
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+<div>This is a test email with 1 attachment.</div>
+
+--001a11447dc881e40b0537fe6d58--
+
+--001a11447dc881e40f0537fe6d5a
+Content-Type: application/vnd.openxmlformats-officedocument.wordprocessingml.document;
+    name="DockMcWordface.docx"
+Content-Disposition: attachment; filename="DockMcWordface.docx"
+Content-Transfer-Encoding: base64
+X-Attachment-Id: f_iqtleujy0
+
+UEsDBBQACAgIAHc+80gAAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcu
+eG1spZJBboMwEEVP0Dsg7xNIF1WFQrNo1G66a3uAiTFgxfZYYwPN7euEAC2V
+KkpXCMb//e/hb3cfWkWNICfRZGyzTlgkDMdcmjJj729Pq3sWOQ8mB4VGZOwk
+HNs93Gzb1NT6ICiciwLCuFTzjFXe2zSOHa+EBrdGK0wYFkgafHilMtZAx9qu
+OGoLXh6kkv4U3ybJHbtiMGM1mfSKWGnJCR0W/ixJsSgkF9dHr6A5vp1kj7zW
+wviLY0xChQxoXCWt62l6KS0Mqx7S/HaJRqv+XGvnuOUEbdizVp1Ri5RbQi6c
+C1/33XAgbpIZCzwjBsWcCN89+yQapBkw53ZMQIP3Onhfl3ZBjRcZd+HUnCDd
+6EUeCOj0MwUs2OdXvZWzWjwhBJWvaSjkEgSvgHwPUEsICvlR5I9gGhjKnJez
+6jwh5RJKAj2W1P3pz26SSV1eK7BipJX/oz0T1pbFD59QSwcIJ5yx3VgBAAC7
+BAAAUEsDBBQACAgIAHc+80gAAAAAAAAAAAAAAAARAAAAd29yZC9zZXR0aW5n
+cy54bWyllMFuozAQhp9g3wH5nkCqardCJZXaqnvZPaV9gIltwIrtscYGNm+/
+JgTYZqWKpieMx/P94/GvuX/4Y3TSSvIKbcE264wl0nIUylYFe3t9Wd2xxAew
+AjRaWbCj9Oxh++2+y70MIZ7ySSRYnxtesDoEl6ep57U04NfopI3BEslAiL9U
+pQbo0LgVR+MgqL3SKhzTmyz7zs4YLFhDNj8jVkZxQo9l6FNyLEvF5fkzZtAS
+3SHlGXljpA0nxZSkjjWg9bVyfqSZa2kxWI+Q9qNLtEaP5zq3RE0QdLHRRg9C
+HZJwhFx6H3efh+BE3GQLGtgjpowlJbzXHCsxoOyE6c1xAZq011H73LQTar7I
+3AuvlxQyhH6pPQEd/68Crujnv/lOLXLxBSFmhYYmQ16D4DVQGAH6GoJGfpDi
+CWwLk5lFtcjOFyShoCIws0n9p152k13YZVeDkzOt+hrtJ2Hj2DYOIKG803B8
+BH6o4qYVJ6Gky1uIXtqw9HRIltDo8Ar7XUA3Bn/cZEN4GETzajcMtQlyy+LS
+gonmfjezfqOQfaghtfw6vWQ6a6bzDN3+BVBLBwiI6qJIqQEAAIgFAABQSwME
+FAAICAgAdz7zSAAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyl
+lE1OwzAQhU/AHSLv26QsEIqaVogKNuyAA0wdJ7Fqe6yxk9Db4zZ/UCQUysqK
+J+974/GT19sPraJGkJNoMrZaJiwShmMuTZmx97enxT2LnAeTg0IjMnYUjm03
+N+s2LdB4FwW5canmGau8t2kcO14JDW6JVphQLJA0+PBJZayBDrVdcNQWvNxL
+Jf0xvk2SO9ZjMGM1mbRHLLTkhA4Lf5KkWBSSi34ZFDTHt5PskNdaGH92jEmo
+0AMaV0nrBpq+lhaK1QBpfjtEo9XwX2vnuOUEbbgLrTqjFim3hFw4F3Z3XXEk
+rpIZAzwhRsWcFr57Dp1okGbEnJJxARq9l8G7H9oZNR1kmoVTcxrpSi9yT0DH
+n13AFfP8qrdyVoovCEHlaxoDeQ2CV0B+AKhrCAr5QeSPYBoYw5yXs+J8Qcol
+lAR6Cqn7082ukou4vFZgxUQr/0d7Jqwt2/SvT9SmBnSI3gNJUCzerOP+Wdp8
+AlBLBwhpMWDsagEAANgEAABQSwMEFAAICAgAdz7zSAAAAAAAAAAAAAAAAA8A
+AAB3b3JkL3N0eWxlcy54bWzdV+1u2jAUfYK9A8r/NiEEhlBphai6Taq6ae0e
+wDgO8XBsy3ag7OlnJ04CCZkyoKMa/Eh8r++518fHH7m5e01Ib42ExIxOnf61
+5/QQhSzEdDl1frw8XI2dnlSAhoAwiqbOFknn7vbDzWYi1ZYg2dPxVE4SOHVi
+pfjEdSWMUQLkNeOIamfERAKUboqlmwCxSvkVZAkHCi8wwWrr+p43ciwMmzqp
+oBMLcZVgKJhkkTIhExZFGCL7KCJEl7x5yD2DaYKoyjK6AhFdA6MyxlwWaMmx
+aNoZFyDrPw1inZCi34Z3yRYKsNGTkZA80YaJkAsGkZTaep87S8S+14FAA1FG
+dClhP2dRSQIwLWGMNGpAZe5rnduSlkFVA6m4kKRLIbnrES8EENtmFeAIPnfj
+Oe6k4hqCjlKpKAV5DASMgVAFADkGgTC4QuEc0DUoxRwuO8m5hhRisBQgqUQq
+/2pm+15NLs8x4KhCW56G9kmwlDu3evsJGbxHEUiJkqYpvgnbtK3s8cCokr3N
+BEiI8dSZCQy05DYTKHcaCEg1kxjsmOIZlWV/10AttHUNtEq9vI1rbZkAQuaA
+y7pdCbxCNSNkhInSlv1s71+F1fcLy1zWbWlhoHpLzk16B1czgpe0cC2ARATn
+btcS4tZp4vWWeawQ4k/oVdVqNuZHDVgf4AaHbDPXPAtGClff1s4B1HNm+I8U
+EiZEvy+QVh+yDVOiHtjHUdH4nhJtAKlilmcaGg+KlI0QeBkX7xEWUj1mELaa
+n7CowYTYwXM7+N3hug0FZeeZjlZbrvE4EGYd8NjkyVxfwqnzZNZNppAwjzRj
+NcEUJKialaxTnjsLbcIrsCBoD/rFWDrhZz17Tx2yHB7EZwTM8d4EjnNHz06f
+kVD4tVRUlVBH7ehj194ioX6LhNp00vf3lBJ4Xps8oBaeTpQC8lyCVNBuWZHd
+EKr1FXjN9ZXbdlbLMbT6rbT674zWwehctNY3x4rmwYFtLLedSPOglebBpWke
+77PsvxXLe6dIMDD/xikyPnCKjM9Af9BKf/C+6PfH56J/j+5R9mvQHRygOzgD
+3cNWuofvjO7gX9Ldekc6ke5RK92j/5VuXEt8EfpfsNK3osZ9J7NemPfR4bvr
+2e4jwwNkDk8i8zldqIN8lo4LUzrw34TTM3701T/yOiyKwYF75aDlXlm8ydvf
+UEsHCCJgqpxzAwAAhxMAAFBLAwQUAAgICAB3PvNIAAAAAAAAAAAAAAAAEQAA
+AHdvcmQvZG9jdW1lbnQueG1spZXfbtsgFMafYO8QcZ/YibKpsur0YlF3s01R
+2z0AAWyjAAcdcNLs6Qf+2yVV5WW+QZzD+X2f4QjuH161mh0FOgkmJ8tFSmbC
+MODSlDn59fI4vyMz56nhVIEROTkLRx42n+5PGQdWa2H8LBCMyzTLSeW9zZLE
+sUpo6hZghQnJAlBTH6ZYJpriobZzBtpSL/dSSX9OVmn6hXQYyEmNJusQcy0Z
+goPCx5IMikIy0Q19BU7RbUu2neVGMUGhggcwrpLW9TR9Ky0kqx5y/Ognjlr1
+6052ihpHegrHoVUrdALkFoEJ50J02yYH4jKdsIERMVRMsfC3Zu9EU2kGTGyO
+C9CgvQja3aY1qPFHxr1waoqRNvVd7pHi+doFvWE/39ZbOamLLwihytc4NOQt
+CFZR9D1A3UJQwA6Cf6XmSIdm5uWkdr4gcUlLpHpsUvdPJ7tML9rluaJWjLTy
+/2jfEGpLNuEC2lN2KMPM8NkpY6Ag3ASPzUeSJg/8HEcb0uF+4085SbuPdKGt
+UNfB3XXoaSsKWiv/TmaHb4KN3A7jwMB48eprqp4tZcF4KDjSKBfdJcM6/MjK
+O5avBbEDeXUp0WTi2ArGVU4w36635fPvUFCFW//z3brhh7tguVqt03b/bPmD
+Rnd78B5CIy3X7SoPdpwoUfhxhrKs+mnH+Fnrl7MVIRmeEYzJzlzvJOlPKhnf
+lM0fUEsHCOH0LWYNAgAAmAYAAFBLAwQUAAgICAB3PvNIAAAAAAAAAAAAAAAA
+HAAAAHdvcmQvX3JlbHMvZG9jdW1lbnQueG1sLnJlbHOtkktqAzEMhk/QOxjt
+O54kpZQSTzYlkG2ZHsCZ0TyILRtLKZ3b1xTyghC6mKV+o0+fkNebH+/UNyYe
+AxlYFCUopCa0I/UGvurt8xsoFkutdYHQwIQMm+pp/YnOSu7hYYysMoTYwCAS
+37XmZkBvuQgRKb90IXkruUy9jrY52B71sixfdbpmQHXDVLvWQNq1C1D1FPE/
+7NB1Y4MfoTl6JLkzQjOK5MU4M23qUQyckiKzQN9XWM6p0AWS2u4dXhzO0SOJ
+1ZwSdPR7THnvi8Q5eiTxMusxZHJ4fYq/+jRe33yw6hdQSwcIY4WdHeEAAACo
+AgAAUEsDBBQACAgIAHc+80gAAAAAAAAAAAAAAAALAAAAX3JlbHMvLnJlbHON
+zzsOwjAMBuATcIfIO03LgBBq0gUhdUXlAFHiphHNQ0l49PZkYADEwGj792e5
+7R52JjeMyXjHoKlqIOikV8ZpBufhuN4BSVk4JWbvkMGCCTq+ak84i1x20mRC
+IgVxicGUc9hTmuSEVqTKB3RlMvpoRS5l1DQIeREa6aautzS+G8A/TNIrBrFX
+DZBhCfiP7cfRSDx4ebXo8o8TX4kii6gxM7j7qKh6tavCAuUt/XiRPwFQSwcI
+LWjPIrEAAAAqAQAAUEsDBBQACAgIAHc+80gAAAAAAAAAAAAAAAATAAAAW0Nv
+bnRlbnRfVHlwZXNdLnhtbLWTTU7DMBCFT8AdIm9R4sICIdS0C36WwKIcYOpM
+Wgv/yTMp7e2ZtCGLqkiwyM7jN/Pe55E8X+69K3aYycZQq5tqpgoMJjY2bGr1
+sXop71VBDKEBFwPW6oCklour+eqQkAoZDlSrLXN60JrMFj1QFRMGUdqYPbCU
+eaMTmE/YoL6dze60iYExcMm9h1rMn7CFznHxeLrvrWsFKTlrgIVLi5kqnvci
+njD7Wv9hbheaM5hyAKkyumMPbW2i6/MAUalPeJPNZNvgvyJi21qDTTSdl5Hq
+K+Ym5WiQSJbqXUXILKch9R0yv4IXW9136h+1Gh45DQIfHP4GcNQmjW/FawVr
+h5cJRnlSiND5NWY5X4YY5UkhRsWDDZdBxpaBQx+/3uIbUEsHCAD+7s4fAQAA
+ugMAAFBLAQIUABQACAgIAHc+80gnnLHdWAEAALsEAAASAAAAAAAAAAAAAAAA
+AAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICAB3PvNIiOqiSKkB
+AACIBQAAEQAAAAAAAAAAAAAAAACYAQAAd29yZC9zZXR0aW5ncy54bWxQSwEC
+FAAUAAgICAB3PvNIaTFg7GoBAADYBAAAEgAAAAAAAAAAAAAAAACAAwAAd29y
+ZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAdz7zSCJgqpxzAwAAhxMAAA8A
+AAAAAAAAAAAAAAAAKgUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAHc+
+80jh9C1mDQIAAJgGAAARAAAAAAAAAAAAAAAAANoIAAB3b3JkL2RvY3VtZW50
+LnhtbFBLAQIUABQACAgIAHc+80hjhZ0d4QAAAKgCAAAcAAAAAAAAAAAAAAAA
+ACYLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgA
+dz7zSC1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAUQwAAF9yZWxzLy5yZWxz
+UEsBAhQAFAAICAgAdz7zSAD+7s4fAQAAugMAABMAAAAAAAAAAAAAAAAAOw0A
+AFtDb250ZW50X1R5cGVzXS54bWxQSwUGAAAAAAgACAD/AQAAmw4AAAAA
+
+--001a11447dc881e40f0537fe6d5a--
+EOL;
+
+        $messageWithoutAttachmentFilename = <<<EOL
+--001a11447dc881e40f0537fe6d5a
+Content-Type: multipart/alternative; boundary=001a11447dc881e40b0537fe6d58
+
+--001a11447dc881e40b0537fe6d58
+Content-Type: text/plain; charset=UTF-8
+
+This is a test email with 1 attachment.
+
+--001a11447dc881e40b0537fe6d58
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+<div>This is a test email with 1 attachment.</div>
+
+--001a11447dc881e40b0537fe6d58--
+
+--001a11447dc881e40f0537fe6d5a
+Content-Type: application/vnd.openxmlformats-officedocument.wordprocessingml.document;
+    name="DockMcWordface.docx"
+Content-Disposition: attachment;
+Content-Transfer-Encoding: base64
+X-Attachment-Id: f_iqtleujy0
+
+UEsDBBQACAgIAHc+80gAAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcu
+eG1spZJBboMwEEVP0Dsg7xNIF1WFQrNo1G66a3uAiTFgxfZYYwPN7euEAC2V
+KkpXCMb//e/hb3cfWkWNICfRZGyzTlgkDMdcmjJj729Pq3sWOQ8mB4VGZOwk
+HNs93Gzb1NT6ICiciwLCuFTzjFXe2zSOHa+EBrdGK0wYFkgafHilMtZAx9qu
+OGoLXh6kkv4U3ybJHbtiMGM1mfSKWGnJCR0W/ixJsSgkF9dHr6A5vp1kj7zW
+wviLY0xChQxoXCWt62l6KS0Mqx7S/HaJRqv+XGvnuOUEbdizVp1Ri5RbQi6c
+C1/33XAgbpIZCzwjBsWcCN89+yQapBkw53ZMQIP3Onhfl3ZBjRcZd+HUnCDd
+6EUeCOj0MwUs2OdXvZWzWjwhBJWvaSjkEgSvgHwPUEsICvlR5I9gGhjKnJez
+6jwh5RJKAj2W1P3pz26SSV1eK7BipJX/oz0T1pbFD59QSwcIJ5yx3VgBAAC7
+BAAAUEsDBBQACAgIAHc+80gAAAAAAAAAAAAAAAARAAAAd29yZC9zZXR0aW5n
+cy54bWyllMFuozAQhp9g3wH5nkCqardCJZXaqnvZPaV9gIltwIrtscYGNm+/
+JgTYZqWKpieMx/P94/GvuX/4Y3TSSvIKbcE264wl0nIUylYFe3t9Wd2xxAew
+AjRaWbCj9Oxh++2+y70MIZ7ySSRYnxtesDoEl6ep57U04NfopI3BEslAiL9U
+pQbo0LgVR+MgqL3SKhzTmyz7zs4YLFhDNj8jVkZxQo9l6FNyLEvF5fkzZtAS
+3SHlGXljpA0nxZSkjjWg9bVyfqSZa2kxWI+Q9qNLtEaP5zq3RE0QdLHRRg9C
+HZJwhFx6H3efh+BE3GQLGtgjpowlJbzXHCsxoOyE6c1xAZq011H73LQTar7I
+3AuvlxQyhH6pPQEd/68Crujnv/lOLXLxBSFmhYYmQ16D4DVQGAH6GoJGfpDi
+CWwLk5lFtcjOFyShoCIws0n9p152k13YZVeDkzOt+hrtJ2Hj2DYOIKG803B8
+BH6o4qYVJ6Gky1uIXtqw9HRIltDo8Ar7XUA3Bn/cZEN4GETzajcMtQlyy+LS
+gonmfjezfqOQfaghtfw6vWQ6a6bzDN3+BVBLBwiI6qJIqQEAAIgFAABQSwME
+FAAICAgAdz7zSAAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyl
+lE1OwzAQhU/AHSLv26QsEIqaVogKNuyAA0wdJ7Fqe6yxk9Db4zZ/UCQUysqK
+J+974/GT19sPraJGkJNoMrZaJiwShmMuTZmx97enxT2LnAeTg0IjMnYUjm03
+N+s2LdB4FwW5canmGau8t2kcO14JDW6JVphQLJA0+PBJZayBDrVdcNQWvNxL
+Jf0xvk2SO9ZjMGM1mbRHLLTkhA4Lf5KkWBSSi34ZFDTHt5PskNdaGH92jEmo
+0AMaV0nrBpq+lhaK1QBpfjtEo9XwX2vnuOUEbbgLrTqjFim3hFw4F3Z3XXEk
+rpIZAzwhRsWcFr57Dp1okGbEnJJxARq9l8G7H9oZNR1kmoVTcxrpSi9yT0DH
+n13AFfP8qrdyVoovCEHlaxoDeQ2CV0B+AKhrCAr5QeSPYBoYw5yXs+J8Qcol
+lAR6Cqn7082ukou4vFZgxUQr/0d7Jqwt2/SvT9SmBnSI3gNJUCzerOP+Wdp8
+AlBLBwhpMWDsagEAANgEAABQSwMEFAAICAgAdz7zSAAAAAAAAAAAAAAAAA8A
+AAB3b3JkL3N0eWxlcy54bWzdV+1u2jAUfYK9A8r/NiEEhlBphai6Taq6ae0e
+wDgO8XBsy3ag7OlnJ04CCZkyoKMa/Eh8r++518fHH7m5e01Ib42ExIxOnf61
+5/QQhSzEdDl1frw8XI2dnlSAhoAwiqbOFknn7vbDzWYi1ZYg2dPxVE4SOHVi
+pfjEdSWMUQLkNeOIamfERAKUboqlmwCxSvkVZAkHCi8wwWrr+p43ciwMmzqp
+oBMLcZVgKJhkkTIhExZFGCL7KCJEl7x5yD2DaYKoyjK6AhFdA6MyxlwWaMmx
+aNoZFyDrPw1inZCi34Z3yRYKsNGTkZA80YaJkAsGkZTaep87S8S+14FAA1FG
+dClhP2dRSQIwLWGMNGpAZe5rnduSlkFVA6m4kKRLIbnrES8EENtmFeAIPnfj
+Oe6k4hqCjlKpKAV5DASMgVAFADkGgTC4QuEc0DUoxRwuO8m5hhRisBQgqUQq
+/2pm+15NLs8x4KhCW56G9kmwlDu3evsJGbxHEUiJkqYpvgnbtK3s8cCokr3N
+BEiI8dSZCQy05DYTKHcaCEg1kxjsmOIZlWV/10AttHUNtEq9vI1rbZkAQuaA
+y7pdCbxCNSNkhInSlv1s71+F1fcLy1zWbWlhoHpLzk16B1czgpe0cC2ARATn
+btcS4tZp4vWWeawQ4k/oVdVqNuZHDVgf4AaHbDPXPAtGClff1s4B1HNm+I8U
+EiZEvy+QVh+yDVOiHtjHUdH4nhJtAKlilmcaGg+KlI0QeBkX7xEWUj1mELaa
+n7CowYTYwXM7+N3hug0FZeeZjlZbrvE4EGYd8NjkyVxfwqnzZNZNppAwjzRj
+NcEUJKialaxTnjsLbcIrsCBoD/rFWDrhZz17Tx2yHB7EZwTM8d4EjnNHz06f
+kVD4tVRUlVBH7ehj194ioX6LhNp00vf3lBJ4Xps8oBaeTpQC8lyCVNBuWZHd
+EKr1FXjN9ZXbdlbLMbT6rbT674zWwehctNY3x4rmwYFtLLedSPOglebBpWke
+77PsvxXLe6dIMDD/xikyPnCKjM9Af9BKf/C+6PfH56J/j+5R9mvQHRygOzgD
+3cNWuofvjO7gX9Ldekc6ke5RK92j/5VuXEt8EfpfsNK3osZ9J7NemPfR4bvr
+2e4jwwNkDk8i8zldqIN8lo4LUzrw34TTM3701T/yOiyKwYF75aDlXlm8ydvf
+UEsHCCJgqpxzAwAAhxMAAFBLAwQUAAgICAB3PvNIAAAAAAAAAAAAAAAAEQAA
+AHdvcmQvZG9jdW1lbnQueG1spZXfbtsgFMafYO8QcZ/YibKpsur0YlF3s01R
+2z0AAWyjAAcdcNLs6Qf+2yVV5WW+QZzD+X2f4QjuH161mh0FOgkmJ8tFSmbC
+MODSlDn59fI4vyMz56nhVIEROTkLRx42n+5PGQdWa2H8LBCMyzTLSeW9zZLE
+sUpo6hZghQnJAlBTH6ZYJpriobZzBtpSL/dSSX9OVmn6hXQYyEmNJusQcy0Z
+goPCx5IMikIy0Q19BU7RbUu2neVGMUGhggcwrpLW9TR9Ky0kqx5y/Ognjlr1
+6052ihpHegrHoVUrdALkFoEJ50J02yYH4jKdsIERMVRMsfC3Zu9EU2kGTGyO
+C9CgvQja3aY1qPFHxr1waoqRNvVd7pHi+doFvWE/39ZbOamLLwihytc4NOQt
+CFZR9D1A3UJQwA6Cf6XmSIdm5uWkdr4gcUlLpHpsUvdPJ7tML9rluaJWjLTy
+/2jfEGpLNuEC2lN2KMPM8NkpY6Ag3ASPzUeSJg/8HEcb0uF+4085SbuPdKGt
+UNfB3XXoaSsKWiv/TmaHb4KN3A7jwMB48eprqp4tZcF4KDjSKBfdJcM6/MjK
+O5avBbEDeXUp0WTi2ArGVU4w36635fPvUFCFW//z3brhh7tguVqt03b/bPmD
+Rnd78B5CIy3X7SoPdpwoUfhxhrKs+mnH+Fnrl7MVIRmeEYzJzlzvJOlPKhnf
+lM0fUEsHCOH0LWYNAgAAmAYAAFBLAwQUAAgICAB3PvNIAAAAAAAAAAAAAAAA
+HAAAAHdvcmQvX3JlbHMvZG9jdW1lbnQueG1sLnJlbHOtkktqAzEMhk/QOxjt
+O54kpZQSTzYlkG2ZHsCZ0TyILRtLKZ3b1xTyghC6mKV+o0+fkNebH+/UNyYe
+AxlYFCUopCa0I/UGvurt8xsoFkutdYHQwIQMm+pp/YnOSu7hYYysMoTYwCAS
+37XmZkBvuQgRKb90IXkruUy9jrY52B71sixfdbpmQHXDVLvWQNq1C1D1FPE/
+7NB1Y4MfoTl6JLkzQjOK5MU4M23qUQyckiKzQN9XWM6p0AWS2u4dXhzO0SOJ
+1ZwSdPR7THnvi8Q5eiTxMusxZHJ4fYq/+jRe33yw6hdQSwcIY4WdHeEAAACo
+AgAAUEsDBBQACAgIAHc+80gAAAAAAAAAAAAAAAALAAAAX3JlbHMvLnJlbHON
+zzsOwjAMBuATcIfIO03LgBBq0gUhdUXlAFHiphHNQ0l49PZkYADEwGj792e5
+7R52JjeMyXjHoKlqIOikV8ZpBufhuN4BSVk4JWbvkMGCCTq+ak84i1x20mRC
+IgVxicGUc9hTmuSEVqTKB3RlMvpoRS5l1DQIeREa6aautzS+G8A/TNIrBrFX
+DZBhCfiP7cfRSDx4ebXo8o8TX4kii6gxM7j7qKh6tavCAuUt/XiRPwFQSwcI
+LWjPIrEAAAAqAQAAUEsDBBQACAgIAHc+80gAAAAAAAAAAAAAAAATAAAAW0Nv
+bnRlbnRfVHlwZXNdLnhtbLWTTU7DMBCFT8AdIm9R4sICIdS0C36WwKIcYOpM
+Wgv/yTMp7e2ZtCGLqkiwyM7jN/Pe55E8X+69K3aYycZQq5tqpgoMJjY2bGr1
+sXop71VBDKEBFwPW6oCklour+eqQkAoZDlSrLXN60JrMFj1QFRMGUdqYPbCU
+eaMTmE/YoL6dze60iYExcMm9h1rMn7CFznHxeLrvrWsFKTlrgIVLi5kqnvci
+njD7Wv9hbheaM5hyAKkyumMPbW2i6/MAUalPeJPNZNvgvyJi21qDTTSdl5Hq
+K+Ym5WiQSJbqXUXILKch9R0yv4IXW9136h+1Gh45DQIfHP4GcNQmjW/FawVr
+h5cJRnlSiND5NWY5X4YY5UkhRsWDDZdBxpaBQx+/3uIbUEsHCAD+7s4fAQAA
+ugMAAFBLAQIUABQACAgIAHc+80gnnLHdWAEAALsEAAASAAAAAAAAAAAAAAAA
+AAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICAB3PvNIiOqiSKkB
+AACIBQAAEQAAAAAAAAAAAAAAAACYAQAAd29yZC9zZXR0aW5ncy54bWxQSwEC
+FAAUAAgICAB3PvNIaTFg7GoBAADYBAAAEgAAAAAAAAAAAAAAAACAAwAAd29y
+ZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAdz7zSCJgqpxzAwAAhxMAAA8A
+AAAAAAAAAAAAAAAAKgUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAHc+
+80jh9C1mDQIAAJgGAAARAAAAAAAAAAAAAAAAANoIAAB3b3JkL2RvY3VtZW50
+LnhtbFBLAQIUABQACAgIAHc+80hjhZ0d4QAAAKgCAAAcAAAAAAAAAAAAAAAA
+ACYLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgA
+dz7zSC1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAUQwAAF9yZWxzLy5yZWxz
+UEsBAhQAFAAICAgAdz7zSAD+7s4fAQAAugMAABMAAAAAAAAAAAAAAAAAOw0A
+AFtDb250ZW50X1R5cGVzXS54bWxQSwUGAAAAAAgACAD/AQAAmw4AAAAA
+
+--001a11447dc881e40f0537fe6d5a--
+EOL;
+
+        return [
+            [
+                $messageWithAttachmentFilename,
+                "DockMcWordface.docx",
+            ],
+            [
+                $messageWithoutAttachmentFilename,
+                null,
+            ],
+        ];
     }
 }

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace LaminasTest\Mime;
 
+use Laminas\Mail\Headers;
 use Laminas\Mime;
+use Laminas\Mime\AlternativePart;
 use Laminas\Mime\Message;
+use Laminas\Mime\Part;
 use PHPUnit\Framework\TestCase;
 
 use function count;
@@ -220,5 +223,178 @@ EOD;
 
         $this->assertEquals(1, count($parts));
         $this->assertEquals('attachment; filename="test.txt"', $parts[0]->getDisposition());
+    }
+
+    public function testDecodeMultipartMimeMessageWithMessagePartAlternatives()
+    {
+        $rawMessage = <<<EOL
+--001a11447dc881e40f0537fe6d5a
+Content-Type: multipart/alternative; boundary=001a11447dc881e40b0537fe6d58
+
+--001a11447dc881e40b0537fe6d58
+Content-Type: text/plain; charset=UTF-8
+
+This is a test email with 1 attachment.
+
+--001a11447dc881e40b0537fe6d58
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+<div dir=3D"ltr">This is a test email with 1 attachment.<br clear=3D"all"><=
+div><br></div>-- <br><div class=3D"gmail_signature" data-smartmail=3D"gmail=
+_signature"><div dir=3D"ltr"><img src=3D"https://sendgrid.com/brand/sg-logo=
+-email.png" width=3D"96" height=3D"17"><br><div><br></div></div></div>
+</div>
+
+--001a11447dc881e40b0537fe6d58--
+
+--001a11447dc881e40f0537fe6d5a
+Content-Type: application/vnd.openxmlformats-officedocument.wordprocessingml.document;
+    name="DockMcWordface.docx"
+Content-Disposition: attachment; filename="DockMcWordface.docx"
+Content-Transfer-Encoding: base64
+X-Attachment-Id: f_iqtleujy0
+
+UEsDBBQACAgIAHc+80gAAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcu
+eG1spZJBboMwEEVP0Dsg7xNIF1WFQrNo1G66a3uAiTFgxfZYYwPN7euEAC2V
+KkpXCMb//e/hb3cfWkWNICfRZGyzTlgkDMdcmjJj729Pq3sWOQ8mB4VGZOwk
+HNs93Gzb1NT6ICiciwLCuFTzjFXe2zSOHa+EBrdGK0wYFkgafHilMtZAx9qu
+OGoLXh6kkv4U3ybJHbtiMGM1mfSKWGnJCR0W/ixJsSgkF9dHr6A5vp1kj7zW
+wviLY0xChQxoXCWt62l6KS0Mqx7S/HaJRqv+XGvnuOUEbdizVp1Ri5RbQi6c
+C1/33XAgbpIZCzwjBsWcCN89+yQapBkw53ZMQIP3Onhfl3ZBjRcZd+HUnCDd
+6EUeCOj0MwUs2OdXvZWzWjwhBJWvaSjkEgSvgHwPUEsICvlR5I9gGhjKnJez
+6jwh5RJKAj2W1P3pz26SSV1eK7BipJX/oz0T1pbFD59QSwcIJ5yx3VgBAAC7
+BAAAUEsDBBQACAgIAHc+80gAAAAAAAAAAAAAAAARAAAAd29yZC9zZXR0aW5n
+cy54bWyllMFuozAQhp9g3wH5nkCqardCJZXaqnvZPaV9gIltwIrtscYGNm+/
+JgTYZqWKpieMx/P94/GvuX/4Y3TSSvIKbcE264wl0nIUylYFe3t9Wd2xxAew
+AjRaWbCj9Oxh++2+y70MIZ7ySSRYnxtesDoEl6ep57U04NfopI3BEslAiL9U
+pQbo0LgVR+MgqL3SKhzTmyz7zs4YLFhDNj8jVkZxQo9l6FNyLEvF5fkzZtAS
+3SHlGXljpA0nxZSkjjWg9bVyfqSZa2kxWI+Q9qNLtEaP5zq3RE0QdLHRRg9C
+HZJwhFx6H3efh+BE3GQLGtgjpowlJbzXHCsxoOyE6c1xAZq011H73LQTar7I
+3AuvlxQyhH6pPQEd/68Crujnv/lOLXLxBSFmhYYmQ16D4DVQGAH6GoJGfpDi
+CWwLk5lFtcjOFyShoCIws0n9p152k13YZVeDkzOt+hrtJ2Hj2DYOIKG803B8
+BH6o4qYVJ6Gky1uIXtqw9HRIltDo8Ar7XUA3Bn/cZEN4GETzajcMtQlyy+LS
+gonmfjezfqOQfaghtfw6vWQ6a6bzDN3+BVBLBwiI6qJIqQEAAIgFAABQSwME
+FAAICAgAdz7zSAAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyl
+lE1OwzAQhU/AHSLv26QsEIqaVogKNuyAA0wdJ7Fqe6yxk9Db4zZ/UCQUysqK
+J+974/GT19sPraJGkJNoMrZaJiwShmMuTZmx97enxT2LnAeTg0IjMnYUjm03
+N+s2LdB4FwW5canmGau8t2kcO14JDW6JVphQLJA0+PBJZayBDrVdcNQWvNxL
+Jf0xvk2SO9ZjMGM1mbRHLLTkhA4Lf5KkWBSSi34ZFDTHt5PskNdaGH92jEmo
+0AMaV0nrBpq+lhaK1QBpfjtEo9XwX2vnuOUEbbgLrTqjFim3hFw4F3Z3XXEk
+rpIZAzwhRsWcFr57Dp1okGbEnJJxARq9l8G7H9oZNR1kmoVTcxrpSi9yT0DH
+n13AFfP8qrdyVoovCEHlaxoDeQ2CV0B+AKhrCAr5QeSPYBoYw5yXs+J8Qcol
+lAR6Cqn7082ukou4vFZgxUQr/0d7Jqwt2/SvT9SmBnSI3gNJUCzerOP+Wdp8
+AlBLBwhpMWDsagEAANgEAABQSwMEFAAICAgAdz7zSAAAAAAAAAAAAAAAAA8A
+AAB3b3JkL3N0eWxlcy54bWzdV+1u2jAUfYK9A8r/NiEEhlBphai6Taq6ae0e
+wDgO8XBsy3ag7OlnJ04CCZkyoKMa/Eh8r++518fHH7m5e01Ib42ExIxOnf61
+5/QQhSzEdDl1frw8XI2dnlSAhoAwiqbOFknn7vbDzWYi1ZYg2dPxVE4SOHVi
+pfjEdSWMUQLkNeOIamfERAKUboqlmwCxSvkVZAkHCi8wwWrr+p43ciwMmzqp
+oBMLcZVgKJhkkTIhExZFGCL7KCJEl7x5yD2DaYKoyjK6AhFdA6MyxlwWaMmx
+aNoZFyDrPw1inZCi34Z3yRYKsNGTkZA80YaJkAsGkZTaep87S8S+14FAA1FG
+dClhP2dRSQIwLWGMNGpAZe5rnduSlkFVA6m4kKRLIbnrES8EENtmFeAIPnfj
+Oe6k4hqCjlKpKAV5DASMgVAFADkGgTC4QuEc0DUoxRwuO8m5hhRisBQgqUQq
+/2pm+15NLs8x4KhCW56G9kmwlDu3evsJGbxHEUiJkqYpvgnbtK3s8cCokr3N
+BEiI8dSZCQy05DYTKHcaCEg1kxjsmOIZlWV/10AttHUNtEq9vI1rbZkAQuaA
+y7pdCbxCNSNkhInSlv1s71+F1fcLy1zWbWlhoHpLzk16B1czgpe0cC2ARATn
+btcS4tZp4vWWeawQ4k/oVdVqNuZHDVgf4AaHbDPXPAtGClff1s4B1HNm+I8U
+EiZEvy+QVh+yDVOiHtjHUdH4nhJtAKlilmcaGg+KlI0QeBkX7xEWUj1mELaa
+n7CowYTYwXM7+N3hug0FZeeZjlZbrvE4EGYd8NjkyVxfwqnzZNZNppAwjzRj
+NcEUJKialaxTnjsLbcIrsCBoD/rFWDrhZz17Tx2yHB7EZwTM8d4EjnNHz06f
+kVD4tVRUlVBH7ehj194ioX6LhNp00vf3lBJ4Xps8oBaeTpQC8lyCVNBuWZHd
+EKr1FXjN9ZXbdlbLMbT6rbT674zWwehctNY3x4rmwYFtLLedSPOglebBpWke
+77PsvxXLe6dIMDD/xikyPnCKjM9Af9BKf/C+6PfH56J/j+5R9mvQHRygOzgD
+3cNWuofvjO7gX9Ldekc6ke5RK92j/5VuXEt8EfpfsNK3osZ9J7NemPfR4bvr
+2e4jwwNkDk8i8zldqIN8lo4LUzrw34TTM3701T/yOiyKwYF75aDlXlm8ydvf
+UEsHCCJgqpxzAwAAhxMAAFBLAwQUAAgICAB3PvNIAAAAAAAAAAAAAAAAEQAA
+AHdvcmQvZG9jdW1lbnQueG1spZXfbtsgFMafYO8QcZ/YibKpsur0YlF3s01R
+2z0AAWyjAAcdcNLs6Qf+2yVV5WW+QZzD+X2f4QjuH161mh0FOgkmJ8tFSmbC
+MODSlDn59fI4vyMz56nhVIEROTkLRx42n+5PGQdWa2H8LBCMyzTLSeW9zZLE
+sUpo6hZghQnJAlBTH6ZYJpriobZzBtpSL/dSSX9OVmn6hXQYyEmNJusQcy0Z
+goPCx5IMikIy0Q19BU7RbUu2neVGMUGhggcwrpLW9TR9Ky0kqx5y/Ognjlr1
+6052ihpHegrHoVUrdALkFoEJ50J02yYH4jKdsIERMVRMsfC3Zu9EU2kGTGyO
+C9CgvQja3aY1qPFHxr1waoqRNvVd7pHi+doFvWE/39ZbOamLLwihytc4NOQt
+CFZR9D1A3UJQwA6Cf6XmSIdm5uWkdr4gcUlLpHpsUvdPJ7tML9rluaJWjLTy
+/2jfEGpLNuEC2lN2KMPM8NkpY6Ag3ASPzUeSJg/8HEcb0uF+4085SbuPdKGt
+UNfB3XXoaSsKWiv/TmaHb4KN3A7jwMB48eprqp4tZcF4KDjSKBfdJcM6/MjK
+O5avBbEDeXUp0WTi2ArGVU4w36635fPvUFCFW//z3brhh7tguVqt03b/bPmD
+Rnd78B5CIy3X7SoPdpwoUfhxhrKs+mnH+Fnrl7MVIRmeEYzJzlzvJOlPKhnf
+lM0fUEsHCOH0LWYNAgAAmAYAAFBLAwQUAAgICAB3PvNIAAAAAAAAAAAAAAAA
+HAAAAHdvcmQvX3JlbHMvZG9jdW1lbnQueG1sLnJlbHOtkktqAzEMhk/QOxjt
+O54kpZQSTzYlkG2ZHsCZ0TyILRtLKZ3b1xTyghC6mKV+o0+fkNebH+/UNyYe
+AxlYFCUopCa0I/UGvurt8xsoFkutdYHQwIQMm+pp/YnOSu7hYYysMoTYwCAS
+37XmZkBvuQgRKb90IXkruUy9jrY52B71sixfdbpmQHXDVLvWQNq1C1D1FPE/
+7NB1Y4MfoTl6JLkzQjOK5MU4M23qUQyckiKzQN9XWM6p0AWS2u4dXhzO0SOJ
+1ZwSdPR7THnvi8Q5eiTxMusxZHJ4fYq/+jRe33yw6hdQSwcIY4WdHeEAAACo
+AgAAUEsDBBQACAgIAHc+80gAAAAAAAAAAAAAAAALAAAAX3JlbHMvLnJlbHON
+zzsOwjAMBuATcIfIO03LgBBq0gUhdUXlAFHiphHNQ0l49PZkYADEwGj792e5
+7R52JjeMyXjHoKlqIOikV8ZpBufhuN4BSVk4JWbvkMGCCTq+ak84i1x20mRC
+IgVxicGUc9hTmuSEVqTKB3RlMvpoRS5l1DQIeREa6aautzS+G8A/TNIrBrFX
+DZBhCfiP7cfRSDx4ebXo8o8TX4kii6gxM7j7qKh6tavCAuUt/XiRPwFQSwcI
+LWjPIrEAAAAqAQAAUEsDBBQACAgIAHc+80gAAAAAAAAAAAAAAAATAAAAW0Nv
+bnRlbnRfVHlwZXNdLnhtbLWTTU7DMBCFT8AdIm9R4sICIdS0C36WwKIcYOpM
+Wgv/yTMp7e2ZtCGLqkiwyM7jN/Pe55E8X+69K3aYycZQq5tqpgoMJjY2bGr1
+sXop71VBDKEBFwPW6oCklour+eqQkAoZDlSrLXN60JrMFj1QFRMGUdqYPbCU
+eaMTmE/YoL6dze60iYExcMm9h1rMn7CFznHxeLrvrWsFKTlrgIVLi5kqnvci
+njD7Wv9hbheaM5hyAKkyumMPbW2i6/MAUalPeJPNZNvgvyJi21qDTTSdl5Hq
+K+Ym5WiQSJbqXUXILKch9R0yv4IXW9136h+1Gh45DQIfHP4GcNQmjW/FawVr
+h5cJRnlSiND5NWY5X4YY5UkhRsWDDZdBxpaBQx+/3uIbUEsHCAD+7s4fAQAA
+ugMAAFBLAQIUABQACAgIAHc+80gnnLHdWAEAALsEAAASAAAAAAAAAAAAAAAA
+AAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICAB3PvNIiOqiSKkB
+AACIBQAAEQAAAAAAAAAAAAAAAACYAQAAd29yZC9zZXR0aW5ncy54bWxQSwEC
+FAAUAAgICAB3PvNIaTFg7GoBAADYBAAAEgAAAAAAAAAAAAAAAACAAwAAd29y
+ZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAdz7zSCJgqpxzAwAAhxMAAA8A
+AAAAAAAAAAAAAAAAKgUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAHc+
+80jh9C1mDQIAAJgGAAARAAAAAAAAAAAAAAAAANoIAAB3b3JkL2RvY3VtZW50
+LnhtbFBLAQIUABQACAgIAHc+80hjhZ0d4QAAAKgCAAAcAAAAAAAAAAAAAAAA
+ACYLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgA
+dz7zSC1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAUQwAAF9yZWxzLy5yZWxz
+UEsBAhQAFAAICAgAdz7zSAD+7s4fAQAAugMAABMAAAAAAAAAAAAAAAAAOw0A
+AFtDb250ZW50X1R5cGVzXS54bWxQSwUGAAAAAAgACAD/AQAAmw4AAAAA
+
+--001a11447dc881e40f0537fe6d5a--
+EOL;
+        $boundary = '001a11447dc881e40f0537fe6d5a';
+
+        $message = Message::createFromMessage($rawMessage, $boundary);
+        $parts = $message->getParts();
+
+        $this->assertCount(2, $parts);
+
+        $this->assertInstanceOf(Part::class, $parts[0]);
+        $this->assertCount(2, $parts[0]->getParts());
+
+        $plainTextPart = $parts[0]->getParts()[0];
+        $this->assertSame("text/plain;\r\n charset=\"UTF-8\"", $plainTextPart->getType());
+        $this->assertSame("This is a test email with 1 attachment.", trim($plainTextPart->getContent()));
+
+        $htmlPart = $parts[0]->getParts()[1];
+        $this->assertSame("text/html;\r\n charset=\"UTF-8\"", $htmlPart->getType());
+        $partHeaders = trim(str_replace(["\r\n"], '', $htmlPart->getHeaders()));
+
+        $headers = Headers::fromString(trim(str_replace(["\r\n"], '', $htmlPart->getHeaders())), "\n");
+        $this->assertTrue($headers->has('Content-Transfer-Encoding'));
+        $this->assertSame("quoted-printable", $headers->get('Content-Transfer-Encoding')->getFieldValue());
+
+        $htmlBody = <<<EOF
+<div dir="ltr">This is a test email with 1 attachment.<br clear="all"><div><br></div>-- <br><div class="gmail_signature" data-smartmail="gmail_signature"><div dir="ltr"><img src="https://sendgrid.com/brand/sg-logo-email.png" width="96" height="17"><br><div><br></div></div></div>
+</div>
+EOF;
+        $this->assertSame($htmlBody, trim($htmlPart->getRawContent()));
+
+        $this->assertInstanceOf(Part::class, $parts[1]);
+        $headers = Headers::fromString(trim(str_replace(["\r\n"], '', $parts[1]->getHeaders())), "\n");
+        $this->assertTrue($headers->has('Content-Disposition'));
+        $this->assertSame(
+            "attachment; filename=\"DockMcWordface.docx\"",
+            $headers->get('Content-Disposition')->getFieldValue()
+        );
+        $this->assertSame(
+            "base64",
+            $headers->get('Content-Transfer-Encoding')->getFieldValue()
+        );
+        $this->assertSame(
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document;\r\n name=\"DockMcWordface.docx\"",
+            $headers->get('Content-Type')->getFieldValue()
+        );
     }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | **yes**
| Bugfix        | **yes**
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This change adds the ability to properly parse messages where the parent message's content-type is set to `multipart/alternative` into multiple Part objects. Previously, this content-type header would be ignored, leaving alternative parts being rolled into one single Part object. See [7.2.3 The Multipart/alternative subtype](https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html) for more information.

At the moment, I don't know if this will cause an effective BC break.